### PR TITLE
Set noupdate to 1 for infoenergia email template

### DIFF
--- a/empowering_customize/empowering_customize_data.xml
+++ b/empowering_customize/empowering_customize_data.xml
@@ -11,7 +11,7 @@
             <field name="orientation">Portrait</field>
         </record>
     </data>
-    <data noupdate="0">
+    <data noupdate="1">
         <record model="poweremail.templates" id="env_empowering_report">
             <field name="name">Enviar report Empowering</field>
             <field name="object_name" model="ir.model" search="[('model', '=', 'giscedata.polissa')]"/>


### PR DESCRIPTION
Cada cop que es fa un update de tots els mòduls, es machaca la plantilla de correu d'infoenergia amb els valors que hi ha al XML. No volem que actualitzi la plantilla que hi ha a la BD quan fem update.